### PR TITLE
Add a dummy page for filling the db

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,5 @@
 source "https://rubygems.org"
-ruby 2.1.2
+ruby "2.1.2"
 gem "rails", "4.1.1"
 gem "pg"
 gem "sass-rails", "~> 4.0.3"

--- a/app/views/biographies/new.html.erb
+++ b/app/views/biographies/new.html.erb
@@ -1,0 +1,2 @@
+<h2>Generating Biographies</h2>
+  This may take a while ... come back in 5 minutes. Most pages won't take that long, but some will.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,5 @@
 Rails.application.routes.draw do
-  resources :biographies, only: [:index, :show]
+  resources :biographies, only: [:index, :show, :new]
   resources :biography_statistics, only: [:index, :new]
   resources :names, only: [:index, :show]
   resources :genders, only: [:index, :new]


### PR DESCRIPTION
Navigating to this page triggers the page walker for the wikipedia page specified in a particular variable. This process is intentionally manual and painful, so random people and bots can't trigger screen scrapes of wikipedia. 
