### PR TITLE
Add support for heroku background worker tasks

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,5 +8,6 @@ gem "coffee-rails", "~> 4.0.0"
 gem "jquery-rails"
 gem "jbuilder", "~> 2.0"
 gem "nokogiri"
+gem "sexmachine", "~> 0.1.0"
+gem "delayed_job_active_record"
 gem "rails_12factor"
-gem 'sexmachine', '~> 0.1.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -36,6 +36,11 @@ GEM
       coffee-script-source
       execjs
     coffee-script-source (1.8.0)
+    delayed_job (4.0.4)
+      activesupport (>= 3.0, < 4.2)
+    delayed_job_active_record (4.0.2)
+      activerecord (>= 3.0, < 4.2)
+      delayed_job (>= 3.0, < 4.1)
     erubis (2.7.0)
     execjs (2.2.1)
     hike (1.2.3)
@@ -117,6 +122,7 @@ PLATFORMS
 
 DEPENDENCIES
   coffee-rails (~> 4.0.0)
+  delayed_job_active_record
   jbuilder (~> 2.0)
   jquery-rails
   nokogiri

--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,1 @@
+worker:  bundle exec rake jobs:work

--- a/bin/delayed_job
+++ b/bin/delayed_job
@@ -1,0 +1,5 @@
+#!/usr/bin/env ruby
+
+require File.expand_path(File.join(File.dirname(__FILE__), '..', 'config', 'environment'))
+require 'delayed/command'
+Delayed::Command.new(ARGV).daemonize

--- a/db/migrate/20141104044623_create_delayed_jobs.rb
+++ b/db/migrate/20141104044623_create_delayed_jobs.rb
@@ -1,0 +1,22 @@
+class CreateDelayedJobs < ActiveRecord::Migration
+  def self.up
+    create_table :delayed_jobs, :force => true do |table|
+      table.integer :priority, :default => 0, :null => false # Allows some jobs to jump to the front of the queue
+      table.integer :attempts, :default => 0, :null => false # Provides for retries, but still fail eventually.
+      table.text :handler, :null => false                    # YAML-encoded string of the object that will do work
+      table.text :last_error                                 # reason for last failure (See Note below)
+      table.datetime :run_at                                 # When to run. Could be Time.zone.now for immediately, or sometime in the future.
+      table.datetime :locked_at                              # Set when a client is working on this object
+      table.datetime :failed_at                              # Set when all retries have failed (actually, by default, the record is deleted instead)
+      table.string :locked_by                                # Who is working on this object (if locked)
+      table.string :queue                                    # The name of the queue this job is in
+      table.timestamps
+    end
+
+    add_index :delayed_jobs, [:priority, :run_at], :name => 'delayed_jobs_priority'
+  end
+
+  def self.down
+    drop_table :delayed_jobs
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20141102154729) do
+ActiveRecord::Schema.define(version: 20141104044623) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -33,6 +33,22 @@ ActiveRecord::Schema.define(version: 20141102154729) do
     t.datetime "created_at",     null: false
     t.datetime "updated_at",     null: false
   end
+
+  create_table "delayed_jobs", force: true do |t|
+    t.integer  "priority",   default: 0, null: false
+    t.integer  "attempts",   default: 0, null: false
+    t.text     "handler",                null: false
+    t.text     "last_error"
+    t.datetime "run_at"
+    t.datetime "locked_at"
+    t.datetime "failed_at"
+    t.string   "locked_by"
+    t.string   "queue"
+    t.datetime "created_at"
+    t.datetime "updated_at"
+  end
+
+  add_index "delayed_jobs", ["priority", "run_at"], name: "delayed_jobs_priority", using: :btree
 
   create_table "wiki_biography_classes", force: true do |t|
     t.text     "class_type"


### PR DESCRIPTION
Heroku chokes on long tasks (such as screen scraping), so it's necessary to enable background worker support via the delayed jobs gem, and associated files.
