### PR TITLE
Fix corrupted merge

### DIFF
--- a/app/controllers/biographies_controller.rb
+++ b/app/controllers/biographies_controller.rb
@@ -41,13 +41,9 @@ class BiographiesController < ApplicationController
     strip_from_beginning_of_url = "http://en.wikipedia.org/wiki/Category:"
     strip_from_end_of_url = "-Class_biography_articles"
 
-<<<<<<< HEAD
     beginning_has_been_stripped = strip_string(page, strip_from_beginning_of_url).to_s
     strip_string(beginning_has_been_stripped, strip_from_end_of_url).to_s
-=======
-    substring = strip_string(page, strip_from_beginning_of_url).to_s
-    strip_string(substring, strip_from_end_of_url).to_s
->>>>>>> e9853d2... Respond to Pull Request Comments
+
   end
 
   def generate_names(name_list, start_page)

--- a/app/models/concerns/biography_statistic_variables.rb
+++ b/app/models/concerns/biography_statistic_variables.rb
@@ -1,11 +1,4 @@
 module BiographyStatisticVariables
-<<<<<<< HEAD
-<<<<<<< HEAD
-=======
-
->>>>>>> e9853d2... Respond to Pull Request Comments
-=======
->>>>>>> 3efa2cf... Respond to pull request comments
   LINKS_TO_SHOW = 2000
 
   JOINT_GENDERS = [

--- a/app/models/concerns/gender_percentages.rb
+++ b/app/models/concerns/gender_percentages.rb
@@ -1,11 +1,4 @@
 module GenderPercentages
-<<<<<<< HEAD
-<<<<<<< HEAD
-=======
-
->>>>>>> e9853d2... Respond to Pull Request Comments
-=======
->>>>>>> 3efa2cf... Respond to pull request comments
   def generate_this_percentage(count_1, count_2, statistic_name)
     if count_1 < count_2
       percentage = (count_1 / count_2) * 100

--- a/app/models/concerns/statistics_entry.rb
+++ b/app/models/concerns/statistics_entry.rb
@@ -1,11 +1,4 @@
 module StatisticsEntry
-<<<<<<< HEAD
-<<<<<<< HEAD
-=======
-
->>>>>>> e9853d2... Respond to Pull Request Comments
-=======
->>>>>>> 3efa2cf... Respond to pull request comments
   def create_statistic_entry(statistic_name, entry_type, entry_meta_data)
     BiographyStatistic.where(name: statistic_name).first_or_create do |statistic|
       if entry_type == "percentage"

--- a/app/models/concerns/string_manipulator.rb
+++ b/app/models/concerns/string_manipulator.rb
@@ -1,11 +1,4 @@
 module StringManipulator
-<<<<<<< HEAD
-<<<<<<< HEAD
-=======
-
->>>>>>> e9853d2... Respond to Pull Request Comments
-=======
->>>>>>> 3efa2cf... Respond to pull request comments
   def strip_string(original_string, string_to_strip)
     original_string.gsub(string_to_strip, "")
   end


### PR DESCRIPTION
For some reason the last merge reinstated the >>>>>>head, etc. strings (but not the associated code) into some files (but not all). They've been removed.
